### PR TITLE
Update Environment Variable

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -72,5 +72,5 @@ app.use(
 );
 
 app.listen(process.env.GRAPHQL_SERVER_PORT, () => {
-  console.log(`Squid API listening on port ${process.env.GQL_PORT}`);
+  console.log(`Squid API listening on port ${process.env.GRAPHQL_SERVER_PORT}`);
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -71,6 +71,6 @@ app.use(
   ),
 );
 
-app.listen(process.env.GQL_PORT, () => {
+app.listen(process.env.GRAPHQL_SERVER_PORT, () => {
   console.log(`Squid API listening on port ${process.env.GQL_PORT}`);
 });


### PR DESCRIPTION
This is outdated. Found https://docs.sqd.dev/cloud/reference/manifest/#api

This works to serve graphql, but doesn't show the web interface on /graphql, and /graphiql doesn't get the schema/connection. not sure how to fix this but assume it's also env vars.